### PR TITLE
fcd + Remill - Milestone 2: Remill Subproject

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,96 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        2
+UseTab:          Never
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ find_package(LLVM 4.0 REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
 find_package(PythonLibs 2.7 REQUIRED)
 find_package(capstone REQUIRED)
+find_package(gflags REQUIRED)
+find_package(glog REQUIRED)
 
 # hack: manually import the libclang.so library; the libclang target exported by the
 # find_packge script does not work...
@@ -134,4 +136,4 @@ target_link_libraries(fcd PRIVATE ${LLVM_LIBRARIES})
 target_link_libraries(fcd PRIVATE dl -Wl,--gc-sections)
 
 set_source_files_properties(${pythonbindingsfile} PROPERTIES COMPILE_FLAGS -w)
-target_link_libraries(fcd PRIVATE ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES})
+target_link_libraries(fcd PRIVATE ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES} gflags glog::glog remill)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(Clang REQUIRED CONFIG)
 find_package(PythonLibs 2.7 REQUIRED)
 find_package(capstone REQUIRED)
 find_package(gflags REQUIRED)
+find_package(glog REQUIRED)
 
 # hack: manually import the libclang.so library; the libclang target exported by the
 # find_packge script does not work...
@@ -135,4 +136,4 @@ target_link_libraries(fcd PRIVATE ${LLVM_LIBRARIES})
 target_link_libraries(fcd PRIVATE dl -Wl,--gc-sections)
 
 set_source_files_properties(${pythonbindingsfile} PROPERTIES COMPILE_FLAGS -w)
-target_link_libraries(fcd PRIVATE ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES} gflags remill)
+target_link_libraries(fcd PRIVATE ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES} glog::glog gflags remill)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,45 @@ if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     message(SEND_ERROR "clang is required to build")
 endif()
 
+if(DEFINED ENV{TRAILOFBITS_LIBRARIES})
+    set(LIBRARY_REPOSITORY_ROOT $ENV{TRAILOFBITS_LIBRARIES}
+    CACHE PATH "Location of cxx-common libraries.")
+endif ()
+
+if (DEFINED LIBRARY_REPOSITORY_ROOT)
+    set(TOB_CMAKE_INCLUDE "${LIBRARY_REPOSITORY_ROOT}/cmake_modules/repository.cmake")
+    if (NOT EXISTS "${TOB_CMAKE_INCLUDE}")
+        message(FATAL_ERROR "The library repository could not be found!")
+    endif ()
+
+    message(STATUS "Using the following library repository: ${LIBRARY_REPOSITORY_ROOT}")
+	include("${TOB_CMAKE_INCLUDE}")
+else ()
+    message(FATAL_ERROR "Please define the TRAILOFBITS_LIBRARIES environment variable!")
+endif ()
+
+if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	message(SEND_ERROR "clang is required to build")
+endif()
+
 set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_STANDARD 14)
 
+SET(CMAKE_SKIP_BUILD_RPATH false)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH true) 
+SET(CMAKE_INSTALL_RPATH "${LIBRARY_REPOSITORY_ROOT}/llvm/lib")
+
+# todo: add the following line to cxx-common
+list(APPEND CMAKE_MODULE_PATH "${TRAILOFBITS_LIBRARIES}/llvm/lib/cmake/clang")
 find_package(LLVM 4.0 REQUIRED CONFIG)
+find_package(Clang REQUIRED CONFIG)
 find_package(PythonLibs 2.7 REQUIRED)
 find_package(capstone REQUIRED)
+
+# hack: manually import the libclang.so library; the libclang target exported by the
+# find_packge script does not work...
+add_library(clanglib SHARED IMPORTED)
+set_target_properties(clanglib PROPERTIES IMPORTED_LOCATION "${TRAILOFBITS_LIBRARIES}/llvm/lib/libclang.so")
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} @ ${LLVM_DIR}")
 message(STATUS "Found Python ${PYTHONLIBS_VERSION_STRING} @ ${PYTHON_INCLUDE_PATH}")
@@ -75,20 +108,30 @@ target_compile_options(fcd PRIVATE -fno-exceptions -fno-rtti -ffunction-sections
 
 # The Clang cmake config file is broken on binary distributions. We need a way
 # to tell if libclang was linked against the LLVM shared library.
-execute_process(COMMAND ldd "${LLVM_LIBRARY_DIR}/libclang.so" COMMAND grep -q libLLVM RESULT_VARIABLE linked_to_libllvm)
+# execute_process(COMMAND ldd "${LLVM_LIBRARY_DIR}/libclang.so" COMMAND grep -q libLLVM RESULT_VARIABLE linked_to_libllvm)
 
-if (${linked_to_libllvm} EQUAL 0)
-    message(STATUS "Link to LLVM shared library.")
-    # XXX: This shouldn't reference the specific LLVM version.
-    set(llvm_libs -lLLVM-4.0)
-else()
-    message(STATUS "Link to LLVM static libraries.")
-    llvm_map_components_to_libnames(llvm_libs analysis asmparser bitreader codegen core coverage instcombine instrumentation ipo irreader linker mc mcparser object option passes profiledata scalaropts support target transformutils vectorize)
-endif()
+# if (${linked_to_libllvm} EQUAL 0)
+#     message(STATUS "Link to LLVM shared library.")
+#     # XXX: This shouldn't reference the specific LLVM version.
+#     set(llvm_libs -lLLVM-4.0)
+# else()
+#     message(STATUS "Link to LLVM static libraries.")
+#     llvm_map_components_to_libnames(llvm_libs analysis asmparser bitreader codegen core coverage instcombine instrumentation ipo irreader linker mc mcparser object option passes profiledata scalaropts support target transformutils vectorize)
+# endif()
 
 # Ubuntu does not package ClangConfig
-target_link_libraries(fcd "-L${LLVM_LIBRARY_DIR}" clangIndex clangCodeGen clangFormat clangToolingCore clangRewrite clangFrontend clangDriver clangParse clangSerialization clangSema clangEdit clangAnalysis clangAST clangLex clangBasic)
-target_link_libraries(fcd ${llvm_libs} clang dl -Wl,--gc-sections)
+set(LLVM_LIBRARIES
+	LLVMCore LLVMSupport LLVMAnalysis LLVMipo LLVMIRReader
+	LLVMBitReader LLVMBitWriter LLVMTransformUtils LLVMScalarOpts
+
+	libclang clangIndex clangCodeGen clangFormat clangToolingCore
+	clangRewrite clangFrontend clangDriver clangParse clangSerialization
+	clangSema clangEdit clangAnalysis clangAST clangLex clangBasic
+)
+
+#target_compile_definitions(fcd PRIVATE _GLIBCXX_USE_CXX11_ABI=0)
+target_link_libraries(fcd PRIVATE ${LLVM_LIBRARIES})
+target_link_libraries(fcd PRIVATE dl -Wl,--gc-sections)
 
 set_source_files_properties(${pythonbindingsfile} PROPERTIES COMPILE_FLAGS -w)
-target_link_libraries(fcd ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES})
+target_link_libraries(fcd PRIVATE ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ find_package(Clang REQUIRED CONFIG)
 find_package(PythonLibs 2.7 REQUIRED)
 find_package(capstone REQUIRED)
 find_package(gflags REQUIRED)
-find_package(glog REQUIRED)
 
 # hack: manually import the libclang.so library; the libclang target exported by the
 # find_packge script does not work...
@@ -136,4 +135,4 @@ target_link_libraries(fcd PRIVATE ${LLVM_LIBRARIES})
 target_link_libraries(fcd PRIVATE dl -Wl,--gc-sections)
 
 set_source_files_properties(${pythonbindingsfile} PROPERTIES COMPILE_FLAGS -w)
-target_link_libraries(fcd PRIVATE ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES} gflags glog::glog remill)
+target_link_libraries(fcd PRIVATE ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES} gflags remill)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.2)
 project(fcd)
 
 if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	message(SEND_ERROR "clang is required to build")
+    message(SEND_ERROR "clang is required to build")
 endif()
 
 set(CMAKE_BUILD_TYPE Debug)
@@ -11,9 +11,11 @@ set(CMAKE_CXX_STANDARD 14)
 
 find_package(LLVM 4.0 REQUIRED CONFIG)
 find_package(PythonLibs 2.7 REQUIRED)
+find_package(capstone REQUIRED)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} @ ${LLVM_DIR}")
 message(STATUS "Found Python ${PYTHONLIBS_VERSION_STRING} @ ${PYTHON_INCLUDE_PATH}")
+message(STATUS "Found Capstone @ ${CAPSTONE_INCLUDE_DIRS}")
 
 ### emulator ###
 
@@ -21,14 +23,14 @@ file(GLOB_RECURSE emulatorsources ${PROJECT_SOURCE_DIR}/fcd/*.emulator.cpp)
 
 set(INCBIN_TEMPLATE ${PROJECT_SOURCE_DIR}/fcd/cpu/incbin.${CMAKE_SYSTEM_NAME}.tpl)
 foreach(emulatorsource ${emulatorsources})
-	string(REGEX REPLACE ".+/([^/]+)\.emulator\.cpp" "\\1" emulator_isa "${emulatorsource}")
-	add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s"
-	                   COMMAND "${CMAKE_CXX_COMPILER}" -c -emit-llvm --std=gnu++14 -O3 "${emulatorsource}" -o "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.bc"
-	                   COMMAND sed -e "s/{CPU}/${emulator_isa}/" ${INCBIN_TEMPLATE} > "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s"
-	                   DEPENDS "${emulatorsource}"
-	                   IMPLICIT_DEPENDS CXX "${emulatorsource}"
-	                   )
-	set(emuasms ${emuasms} "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s")
+    string(REGEX REPLACE ".+/([^/]+)\.emulator\.cpp" "\\1" emulator_isa "${emulatorsource}")
+    add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s"
+                       COMMAND "${CMAKE_CXX_COMPILER}" -c -emit-llvm --std=gnu++14 -O3 "${emulatorsource}" -o "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.bc" -I"${CAPSTONE_INCLUDE_DIRS}"
+                       COMMAND sed -e "s/{CPU}/${emulator_isa}/" ${INCBIN_TEMPLATE} > "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s"
+                       DEPENDS "${emulatorsource}"
+                       IMPLICIT_DEPENDS CXX "${emulatorsource}"
+                       )
+    set(emuasms ${emuasms} "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s")
 endforeach()
 enable_language(ASM)
 add_library(emu OBJECT ${emuasms})
@@ -38,7 +40,7 @@ set(subdirs fcd/ fcd/ast fcd/callconv fcd/clang fcd/codegen fcd/cpu fcd/executab
 set(pythonbindingsfile "${CMAKE_CURRENT_BINARY_DIR}/bindings.cpp")
 set(subdirs ${subdirs} fcd/python)
 add_custom_command(OUTPUT ${pythonbindingsfile}
-				   COMMAND "${CMAKE_C_COMPILER}" -E ${LLVM_DEFINITIONS} -isystem ${LLVM_INCLUDE_DIRS} "${LLVM_INCLUDE_DIRS}/llvm-c/Core.h" | python "${PROJECT_SOURCE_DIR}/fcd/python/bindings.py" > ${pythonbindingsfile})
+                   COMMAND "${CMAKE_C_COMPILER}" -E ${LLVM_DEFINITIONS} -isystem ${LLVM_INCLUDE_DIRS} "${LLVM_INCLUDE_DIRS}/llvm-c/Core.h" | python "${PROJECT_SOURCE_DIR}/fcd/python/bindings.py" > ${pythonbindingsfile})
 
 ### header search paths file ###
 execute_process(COMMAND "${CMAKE_CXX_COMPILER}" -E -x c++ -v /dev/null OUTPUT_VARIABLE dummy ERROR_VARIABLE defaultHeaderSearchPathList)
@@ -58,14 +60,15 @@ add_executable(fcd ${sources} ${headers} $<TARGET_OBJECTS:emu> ${pythonbindingsf
 
 # NDEBUG must match llvm's build or it will crash
 if (${LLVM_ENABLE_ASSERTIONS})
-	target_compile_options(fcd PRIVATE -UNDEBUG)
+    target_compile_options(fcd PRIVATE -UNDEBUG)
 else()
-	target_compile_definitions(fcd PRIVATE -DNDEBUG)
+    target_compile_definitions(fcd PRIVATE -DNDEBUG)
 endif()
 
 target_compile_definitions(fcd PRIVATE ${LLVM_DEFINITIONS} FCD_DEBUG=1)
 target_include_directories(fcd PRIVATE ${subdirs})
-target_include_directories(fcd SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
+target_include_directories(fcd SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} ${CAPSTONE_INCLUDE_DIRS})
+
 target_compile_options(fcd PRIVATE --system-header-prefix=llvm/ --system-header-prefix=clang/ --system-header-prefix=clang-c/)
 target_compile_options(fcd PRIVATE -Wall -Werror=conversion -Wno-error=sign-conversion -Wshadow -Wunreachable-code -Wempty-body -Wconditional-uninitialized -Winvalid-offsetof -Wnewline-eof)
 target_compile_options(fcd PRIVATE -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections)
@@ -75,17 +78,17 @@ target_compile_options(fcd PRIVATE -fno-exceptions -fno-rtti -ffunction-sections
 execute_process(COMMAND ldd "${LLVM_LIBRARY_DIR}/libclang.so" COMMAND grep -q libLLVM RESULT_VARIABLE linked_to_libllvm)
 
 if (${linked_to_libllvm} EQUAL 0)
-	message(STATUS "Link to LLVM shared library.")
-	# XXX: This shouldn't reference the specific LLVM version.
-	set(llvm_libs -lLLVM-4.0)
+    message(STATUS "Link to LLVM shared library.")
+    # XXX: This shouldn't reference the specific LLVM version.
+    set(llvm_libs -lLLVM-4.0)
 else()
-	message(STATUS "Link to LLVM static libraries.")
-	llvm_map_components_to_libnames(llvm_libs analysis asmparser bitreader codegen core coverage instcombine instrumentation ipo irreader linker mc mcparser object option passes profiledata scalaropts support target transformutils vectorize)
+    message(STATUS "Link to LLVM static libraries.")
+    llvm_map_components_to_libnames(llvm_libs analysis asmparser bitreader codegen core coverage instcombine instrumentation ipo irreader linker mc mcparser object option passes profiledata scalaropts support target transformutils vectorize)
 endif()
 
 # Ubuntu does not package ClangConfig
 target_link_libraries(fcd "-L${LLVM_LIBRARY_DIR}" clangIndex clangCodeGen clangFormat clangToolingCore clangRewrite clangFrontend clangDriver clangParse clangSerialization clangSema clangEdit clangAnalysis clangAST clangLex clangBasic)
-target_link_libraries(fcd ${llvm_libs} capstone clang dl -Wl,--gc-sections)
+target_link_libraries(fcd ${llvm_libs} clang dl -Wl,--gc-sections)
 
 set_source_files_properties(${pythonbindingsfile} PROPERTIES COMPILE_FLAGS -w)
-target_link_libraries(fcd ${PYTHON_LIBRARIES})
+target_link_libraries(fcd ${PYTHON_LIBRARIES} ${CAPSTONE_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,18 @@ message(STATUS "Found Python ${PYTHONLIBS_VERSION_STRING} @ ${PYTHON_INCLUDE_PAT
 
 ### emulator ###
 
-file(GLOB_RECURSE emulatorsources ${CMAKE_SOURCE_DIR}/fcd/*.emulator.cpp)
+file(GLOB_RECURSE emulatorsources ${PROJECT_SOURCE_DIR}/fcd/*.emulator.cpp)
 
-set(INCBIN_TEMPLATE ${CMAKE_SOURCE_DIR}/fcd/cpu/incbin.${CMAKE_SYSTEM_NAME}.tpl)
+set(INCBIN_TEMPLATE ${PROJECT_SOURCE_DIR}/fcd/cpu/incbin.${CMAKE_SYSTEM_NAME}.tpl)
 foreach(emulatorsource ${emulatorsources})
 	string(REGEX REPLACE ".+/([^/]+)\.emulator\.cpp" "\\1" emulator_isa "${emulatorsource}")
-	add_custom_command(OUTPUT "${CMAKE_BINARY_DIR}/${emulator_isa}.emulator.s"
-	                   COMMAND "${CMAKE_CXX_COMPILER}" -c -emit-llvm --std=gnu++14 -O3 "${emulatorsource}" -o "${CMAKE_BINARY_DIR}/${emulator_isa}.emulator.bc"
-	                   COMMAND sed -e "s/{CPU}/${emulator_isa}/" ${INCBIN_TEMPLATE} > "${CMAKE_BINARY_DIR}/${emulator_isa}.emulator.s"
+	add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s"
+	                   COMMAND "${CMAKE_CXX_COMPILER}" -c -emit-llvm --std=gnu++14 -O3 "${emulatorsource}" -o "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.bc"
+	                   COMMAND sed -e "s/{CPU}/${emulator_isa}/" ${INCBIN_TEMPLATE} > "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s"
 	                   DEPENDS "${emulatorsource}"
 	                   IMPLICIT_DEPENDS CXX "${emulatorsource}"
 	                   )
-	set(emuasms ${emuasms} "${CMAKE_BINARY_DIR}/${emulator_isa}.emulator.s")
+	set(emuasms ${emuasms} "${PROJECT_BINARY_DIR}/${emulator_isa}.emulator.s")
 endforeach()
 enable_language(ASM)
 add_library(emu OBJECT ${emuasms})
@@ -38,7 +38,7 @@ set(subdirs fcd/ fcd/ast fcd/callconv fcd/clang fcd/codegen fcd/cpu fcd/executab
 set(pythonbindingsfile "${CMAKE_CURRENT_BINARY_DIR}/bindings.cpp")
 set(subdirs ${subdirs} fcd/python)
 add_custom_command(OUTPUT ${pythonbindingsfile}
-				   COMMAND "${CMAKE_C_COMPILER}" -E ${LLVM_DEFINITIONS} -isystem ${LLVM_INCLUDE_DIRS} "${LLVM_INCLUDE_DIRS}/llvm-c/Core.h" | python "${CMAKE_SOURCE_DIR}/fcd/python/bindings.py" > ${pythonbindingsfile})
+				   COMMAND "${CMAKE_C_COMPILER}" -E ${LLVM_DEFINITIONS} -isystem ${LLVM_INCLUDE_DIRS} "${LLVM_INCLUDE_DIRS}/llvm-c/Core.h" | python "${PROJECT_SOURCE_DIR}/fcd/python/bindings.py" > ${pythonbindingsfile})
 
 ### header search paths file ###
 execute_process(COMMAND "${CMAKE_CXX_COMPILER}" -E -x c++ -v /dev/null OUTPUT_VARIABLE dummy ERROR_VARIABLE defaultHeaderSearchPathList)

--- a/fcd/main.cpp
+++ b/fcd/main.cpp
@@ -7,16 +7,16 @@
 // license. See LICENSE.md for details.
 //
 
+#include "main.h"
 #include "ast_passes.h"
 #include "command_line.h"
 #include "errors.h"
 #include "executable.h"
 #include "header_decls.h"
-#include "main.h"
 #include "metadata.h"
+#include "params_registry.h"
 #include "passes.h"
 #include "python_context.h"
-#include "params_registry.h"
 #include "translation_context.h"
 
 #include <gflags/gflags.h>
@@ -36,9 +36,9 @@
 #include <llvm/Support/Path.h>
 #include <llvm/Support/PrettyStackTrace.h>
 #include <llvm/Support/Process.h>
-#include <llvm/Support/raw_os_ostream.h>
 #include <llvm/Support/Signals.h>
 #include <llvm/Support/SourceMgr.h>
+#include <llvm/Support/raw_os_ostream.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/GVN.h>
@@ -48,741 +48,670 @@
 #include <iostream>
 #include <map>
 #include <memory>
-#include <unordered_map>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 using namespace llvm;
 using namespace std;
 
 #ifdef FCD_DEBUG
-[[gnu::used]]
-raw_ostream& llvm_errs()
-{
-	return errs();
-}
+[[gnu::used]] raw_ostream& llvm_errs() { return errs(); }
 #endif
 
 DECLARE_string(arch);
 DECLARE_string(os);
 
-namespace
-{
-	cl::opt<string> inputFile(cl::Positional, cl::desc("<input program>"), cl::Required, whitelist());
-	cl::list<unsigned long long> additionalEntryPoints("other-entry", cl::desc("Add entry point from virtual address (can be used multiple times)"), cl::CommaSeparated, whitelist());
-	cl::list<bool> partialDisassembly("partial", cl::desc("Only decompile functions specified with --other-entry"), whitelist());
-	cl::list<bool> inputIsModule("module-in", cl::desc("Input file is a LLVM module"), whitelist());
-	cl::list<bool> outputIsModule("module-out", cl::desc("Output LLVM module"), whitelist());
-	
-	cl::list<string> additionalPasses("opt", cl::desc("Insert LLVM optimization pass; a pass name ending in .py is interpreted as a Python script. Requires default pass pipeline."), whitelist());
-	cl::opt<string> customPassPipeline("opt-pipeline", cl::desc("Customize pass pipeline. Empty string lets you order passes through $EDITOR; otherwise, must be a whitespace-separated list of passes."), cl::init("default"), whitelist());
-	
-	cl::list<string> headers("header", cl::desc("Path of a header file to parse for function declarations. Can be specified multiple times"), whitelist());
-	cl::list<string> frameworks("framework", cl::desc("Path of an Apple framework that fcd should use for declarations. Can be specified multiple times"), whitelist());
-	cl::list<string> headerSearchPath("I", cl::desc("Additional directory to search headers in. Can be specified multiple times"), whitelist());
-	
-	cl::alias additionalEntryPointsAlias("e", cl::desc("Alias for --other-entry"), cl::aliasopt(additionalEntryPoints), whitelist());
-	cl::alias partialDisassemblyAlias("p", cl::desc("Alias for --partial"), cl::aliasopt(partialDisassembly), whitelist());
-	cl::alias additionalPassesAlias("O", cl::desc("Alias for --opt"), cl::aliasopt(additionalPasses), whitelist());
-	cl::alias inputIsModuleAlias("m", cl::desc("Alias for --module-in"), cl::aliasopt(inputIsModule), whitelist());
-	cl::alias outputIsModuleAlias("n", cl::desc("Alias for --module-out"), cl::aliasopt(outputIsModule), whitelist());
-	
-	cl::opt<string> remillArch("arch", cl::Required, cl::desc("Architecture of the code being translated. Valid architectures: x86, amd64 (with or without `_avx` or `_avx512` appended), aarch64, mips32, mips64"), whitelist());
-	cl::opt<string> remillOS("os", cl::Required, cl::desc("Operating system name of the code being translated. Valid OSes: linux, macos, windows."), whitelist());
+namespace {
+cl::opt<string> inputFile(cl::Positional, cl::desc("<input program>"),
+                          cl::Required, whitelist());
+cl::list<unsigned long long> additionalEntryPoints(
+    "other-entry",
+    cl::desc(
+        "Add entry point from virtual address (can be used multiple times)"),
+    cl::CommaSeparated, whitelist());
+cl::list<bool> partialDisassembly(
+    "partial",
+    cl::desc("Only decompile functions specified with --other-entry"),
+    whitelist());
+cl::list<bool> inputIsModule("module-in",
+                             cl::desc("Input file is a LLVM module"),
+                             whitelist());
+cl::list<bool> outputIsModule("module-out", cl::desc("Output LLVM module"),
+                              whitelist());
 
-	template<int (*)()> // templated to ensure multiple instatiation of the static variables
-	inline int optCount(const cl::list<bool>& list)
-	{
-		static int count = 0;
-		static bool counted = false;
-		if (!counted)
-		{
-			for (bool opt : list)
-			{
-				count += opt ? 1 : -1;
-			}
-			counted = true;
-		}
-		return count;
-	}
-	
-	inline int partialOptCount()
-	{
-		return optCount<partialOptCount>(partialDisassembly);
-	}
-	
-	inline int moduleInCount()
-	{
-		return optCount<moduleInCount>(inputIsModule);
-	}
-	
-	inline int moduleOutCount()
-	{
-		return optCount<moduleOutCount>(outputIsModule);
-	}
-	
-	void pruneOptionList(StringMap<cl::Option*>& list)
-	{
-		for (auto& pair : list)
-		{
-			if (!whitelist::isWhitelisted(*pair.second))
-			{
-				pair.second->setHiddenFlag(cl::ReallyHidden);
-			}
-		}
-	}
-	
-	template<typename T>
-	string errorOf(const ErrorOr<T>& error)
-	{
-		return error.getError().message();
-	}
-	
-	template<typename TAction>
-	size_t forEachCall(Function* callee, unsigned stringArgumentIndex, TAction&& action)
-	{
-		size_t count = 0;
-		for (Use& use : callee->uses())
-		{
-			if (auto call = dyn_cast<CallInst>(use.getUser()))
-			{
-				unique_ptr<Instruction> eraseIfNecessary;
-				Value* operand = call->getOperand(stringArgumentIndex);
-				if (auto constant = dyn_cast<ConstantExpr>(operand))
-				{
-					eraseIfNecessary.reset(constant->getAsInstruction());
-					operand = eraseIfNecessary.get();
-				}
-				
-				if (auto gep = dyn_cast<GetElementPtrInst>(operand))
-				if (auto global = dyn_cast<GlobalVariable>(gep->getOperand(0)))
-				if (auto dataArray = dyn_cast<ConstantDataArray>(global->getInitializer()))
-				{
-					action(dataArray->getAsString().str());
-					count++;
-				}
-			}
-		}
-		return count;
-	}
-	
-	bool refillEntryPoints(const TranslationContext& transl, const EntryPointRepository& entryPoints, map<uint64_t, SymbolInfo>& toVisit, size_t iterations)
-	{
-		if (isExclusiveDisassembly() || (isPartialDisassembly() && iterations > 1))
-		{
-			return false;
-		}
-		
-		for (uint64_t entryPoint : transl.getDiscoveredEntryPoints())
-		{
-			if (auto symbolInfo = entryPoints.getInfo(entryPoint))
-			{
-				toVisit.insert({entryPoint, *symbolInfo});
-			}
-		}
-		return !toVisit.empty();
-	}
-	
-	class Main
-	{
-		int argc;
-		char** argv;
-	
-		LLVMContext llvm;
-		PythonContext python;
-		vector<Pass*> optimizeAndTransformPasses;
-		
-		static void aliasAnalysisHooks(Pass& pass, Function& fn, AAResults& aar)
-		{
-			if (auto prgmem = pass.getAnalysisIfAvailable<ProgramMemoryAAWrapperPass>())
-			{
-				aar.addAAResult(prgmem->getResult());
-			}
-			if (auto params = pass.getAnalysisIfAvailable<ParameterRegistry>())
-			{
-				aar.addAAResult(params->getAAResult());
-			}
-		}
-	
-		static legacy::PassManager createBasePassManager()
-		{
-			legacy::PassManager pm;
-			pm.add(createTypeBasedAAWrapperPass());
-			pm.add(createScopedNoAliasAAWrapperPass());
-			pm.add(createBasicAAWrapperPass());
-			pm.add(createProgramMemoryAliasAnalysis());
-			return pm;
-		}
-		
-		vector<Pass*> createPassesFromList(const vector<string>& passNames)
-		{
-			vector<Pass*> result;
-			PassRegistry* pr = PassRegistry::getPassRegistry();
-			for (string passName : passNames)
-			{
-				auto begin = passName.begin();
-				while (begin != passName.end())
-				{
-					if (isspace(*begin))
-					{
-						++begin;
-					}
-					else
-					{
-						break;
-					}
-				}
-				passName.erase(passName.begin(), begin);
-				
-				auto rbegin = passName.rbegin();
-				while (rbegin != passName.rend())
-				{
-					if (isspace(*rbegin))
-					{
-						++rbegin;
-					}
-					else
-					{
-						break;
-					}
-				}
-				passName.erase(rbegin.base(), passName.end());
-				
-				if (passName.size() > 0 && passName[0] != '#')
-				{
-					auto ext = sys::path::extension(passName);
-					if (ext == ".py" || ext == ".pyc" || ext == ".pyo")
-					{
-						if (auto passOrError = python.createPass(passName))
-						{
-							result.push_back(passOrError.get());
-						}
-						else
-						{
-							cerr << getProgramName() << ": couldn't load " << passName << ": " << errorOf(passOrError) << endl;
-							return vector<Pass*>();
-						}
-					}
-					else if (const PassInfo* pi = pr->getPassInfo(passName))
-					{
-						result.push_back(pi->createPass());
-					}
-					else
-					{
-						cerr << getProgramName() << ": couldn't identify pass " << passName << endl;
-						return vector<Pass*>();
-					}
-				}
-			}
-			
-			if (result.size() == 0)
-			{
-				errs() << getProgramName() << ": empty pass list\n";
-			}
-			return result;
-		}
-	
-		vector<Pass*> interactivelyEditPassPipeline(const string& editor, const vector<string>& basePasses)
-		{
-			int fd;
-			SmallVector<char, 100> path;
-			if (auto errorCode = sys::fs::createTemporaryFile("fcd-pass-pipeline", "txt", fd, path))
-			{
-				errs() << getProgramName() << ": can't open temporary file for editing: " << errorCode.message() << "\n";
-				return vector<Pass*>();
-			}
-			
-			raw_fd_ostream passListOs(fd, true);
-			passListOs << "# Enter the name of the LLVM or fcd passes that you want to run on the module.\n";
-			passListOs << "# Files starting with a # symbol are ignored.\n";
-			passListOs << "# Names ending with .py are assumed to be Python scripts implementing passes.\n";
-			for (const string& passName : basePasses)
-			{
-				passListOs << passName << '\n';
-			}
-			passListOs.flush();
-			
-			// shell escape temporary path
-			string escapedPath;
-			escapedPath.reserve(path.size());
-			for (char c : path)
-			{
-				if (c == '\'' || c == '\\')
-				{
-					escapedPath.push_back('\\');
-				}
-				escapedPath.push_back(c);
-			}
-			
-			string editCommand;
-			raw_string_ostream(editCommand) << editor << " '" << escapedPath << "'";
-			if (int errorCode = system(editCommand.c_str()))
-			{
-				errs() << getProgramName() << ": interactive pass pipeline: editor returned status code " << errorCode << '\n';
-				return vector<Pass*>();
-			}
-			
-			ifstream passListIs(path.data());
-			assert(static_cast<bool>(passListIs));
-			
-			string inputLine;
-			vector<string> lines;
-			while (getline(passListIs, inputLine))
-			{
-				lines.push_back(inputLine);
-				inputLine.clear();
-			}
-			if (inputLine.size() != 0)
-			{
-				lines.push_back(inputLine);
-			}
-			
-			return createPassesFromList(lines);
-		}
-		
-		vector<Pass*> readPassPipelineFromString(const string& argString)
-		{
-			stringstream ss(argString, ios::in);
-			vector<string> passes;
-			while (ss)
-			{
-				passes.emplace_back();
-				string& passName = passes.back();
-				ss >> passName;
-				if (passName.size() == 0 || passName[0] == '#')
-				{
-					passes.pop_back();
-				}
-			}
-			auto result = createPassesFromList(passes);
-			if (result.size() == 0)
-			{
-				errs() << getProgramName() << ": empty custom pass list\n";
-			}
-			return result;
-		}
-	
-	public:
-		Main(int argc, char** argv)
-		: argc(argc), argv(argv), python(argv[0])
-		{
-			(void) argc;
-			(void) this->argc;
-		}
-	
-		string getProgramName() { return sys::path::stem(argv[0]); }
-		LLVMContext& getContext() { return llvm; }
-	
-		ErrorOr<unique_ptr<Executable>> parseExecutable(MemoryBuffer& executableCode)
-		{
-			auto start = reinterpret_cast<const uint8_t*>(executableCode.getBufferStart());
-			auto end = reinterpret_cast<const uint8_t*>(executableCode.getBufferEnd());
-			return Executable::parse(start, end);
-		}
-		
-		ErrorOr<unique_ptr<Module>> generateAnnotatedModule(Executable& executable, const string& moduleName = "fcd-out")
-		{
-			x86_config config64 = { x86_isa64, 8, X86_REG_RIP, X86_REG_RSP, X86_REG_RBP };
-			TranslationContext transl(llvm, executable, config64, moduleName);
-			
-			// Load headers here, since this is the earliest point where we have an executable and a module.
-			auto cDecls = HeaderDeclarations::create(
-				transl.get(),
-				headerSearchPath.begin(),
-				headerSearchPath.end(),
-				headers.begin(),
-				headers.end(),
-				frameworks.begin(),
-				frameworks.end(),
-				errs());
-			if (!cDecls)
-			{
-				return make_error_code(FcdError::Main_HeaderParsingError);
-			}
-			
-			EntryPointRepository entryPoints;
-			entryPoints.addProvider(executable);
-			entryPoints.addProvider(*cDecls);
-			
-			md::addIncludedFiles(transl.get(), cDecls->getIncludedFiles());
-	
-			map<uint64_t, SymbolInfo> toVisit;
-			if (isFullDisassembly())
-			{
-				for (uint64_t address : entryPoints.getVisibleEntryPoints())
-				{
-					auto symbolInfo = entryPoints.getInfo(address);
-					assert(symbolInfo != nullptr);
-					toVisit.insert({symbolInfo->virtualAddress, *symbolInfo});
-				}
-			}
-	
-			for (uint64_t address : unordered_set<uint64_t>(additionalEntryPoints.begin(), additionalEntryPoints.end()))
-			{
-				if (auto symbolInfo = entryPoints.getInfo(address))
-				{
-					toVisit.insert({symbolInfo->virtualAddress, *symbolInfo});
-				}
-				else
-				{
-					return make_error_code(FcdError::Main_EntryPointOutOfMappedMemory);
-				}
-			}
-	
-			if (toVisit.size() == 0)
-			{
-				return make_error_code(FcdError::Main_NoEntryPoint);
-			}
-	
-			size_t iterations = 0;
-			do
-			{
-				while (toVisit.size() > 0)
-				{
-					auto iter = toVisit.begin();
-					auto functionInfo = iter->second;
-					toVisit.erase(iter);
-			
-					if (functionInfo.name.size() > 0)
-					{
-						transl.setFunctionName(functionInfo.virtualAddress, functionInfo.name);
-					}
-					
-					if (Function* fn = transl.createFunction(functionInfo.virtualAddress))
-					{
-						if (Function* cFunction = cDecls->prototypeForAddress(functionInfo.virtualAddress))
-						{
-							md::setFinalPrototype(*fn, *cFunction);
-						}
-					}
-					else
-					{
-						// Couldn't decompile, abort
-						return make_error_code(FcdError::Main_DecompilationError);
-					}
-				}
-				iterations++;
-			}
-			while (refillEntryPoints(transl, entryPoints, toVisit, iterations));
-	
-			// Perform early optimizations to make the module suitable for analysis
-			auto module = transl.take();
-			legacy::PassManager phaseOne = createBasePassManager();
-			phaseOne.add(createExternalAAWrapperPass(&Main::aliasAnalysisHooks));
-			phaseOne.add(createDeadCodeEliminationPass());
-			phaseOne.add(createInstructionCombiningPass());
-			phaseOne.add(createRegisterPointerPromotionPass());
-			phaseOne.add(createGVNPass());
-			phaseOne.add(createDeadStoreEliminationPass());
-			phaseOne.add(createInstructionCombiningPass());
-			phaseOne.add(createGlobalDCEPass());
-			phaseOne.run(*module);
-	
-			// Annotate stubs before returning module
-			Function* jumpIntrin = module->getFunction("x86_jump_intrin");
-			vector<Function*> functions;
-			for (Function& fn : module->getFunctionList())
-			{
-				if (md::isPrototype(fn))
-				{
-					continue;
-				}
-				
-				BasicBlock& entry = fn.getEntryBlock();
-				auto terminator = entry.getTerminator();
-				if (isa<UnreachableInst>(terminator))
-				{
-					if (auto prev = dyn_cast<CallInst>(terminator->getPrevNode()))
-					if (prev->getCalledFunction() == jumpIntrin)
-					if (auto load = dyn_cast<LoadInst>(prev->getOperand(2)))
-					if (auto constantExpr = dyn_cast<ConstantExpr>(load->getPointerOperand()))
-					{
-						unique_ptr<Instruction> inst(constantExpr->getAsInstruction());
-						if (auto int2ptr = dyn_cast<IntToPtrInst>(inst.get()))
-						{
-							auto value = cast<ConstantInt>(int2ptr->getOperand(0));
-							if (const StubInfo* stubTarget = executable.getStubTarget(value->getLimitedValue()))
-							{
-								if (Function* cFunction = cDecls->prototypeForImportName(stubTarget->name))
-								{
-									md::setIsStub(fn);
-									md::setFinalPrototype(fn, *cFunction);
-								}
-								
-								// If we identified no function from the header file, this gives the import its real
-								// name. Otherwise, it'll prefix the name with some number.
-								fn.setName(stubTarget->name);
-							}
-						}
-					}
-				}
-			}
-			return move(module);
-		}
-		
-		bool optimizeAndTransformModule(Module& module, raw_ostream& errorOutput, Executable* executable = nullptr)
-		{
-			PrettyStackTraceString optimize("Optimizing LLVM IR");
-			
-			// Phase 3: make into functions with arguments, run codegen.
-			auto passManager = createBasePassManager();
-			passManager.add(new ExecutableWrapper(executable));
-			passManager.add(createParameterRegistryPass());
-			passManager.add(createExternalAAWrapperPass(&Main::aliasAnalysisHooks));
-			for (Pass* pass : optimizeAndTransformPasses)
-			{
-				passManager.add(pass);
-			}
-			passManager.run(module);
-	
+cl::list<string> additionalPasses(
+    "opt",
+    cl::desc("Insert LLVM optimization pass; a pass name ending in .py is "
+             "interpreted as a Python script. Requires default pass pipeline."),
+    whitelist());
+cl::opt<string> customPassPipeline(
+    "opt-pipeline", cl::desc("Customize pass pipeline. Empty string lets you "
+                             "order passes through $EDITOR; otherwise, must be "
+                             "a whitespace-separated list of passes."),
+    cl::init("default"), whitelist());
+
+cl::list<string> headers(
+    "header", cl::desc("Path of a header file to parse for function "
+                       "declarations. Can be specified multiple times"),
+    whitelist());
+cl::list<string> frameworks(
+    "framework", cl::desc("Path of an Apple framework that fcd should use for "
+                          "declarations. Can be specified multiple times"),
+    whitelist());
+cl::list<string> headerSearchPath(
+    "I", cl::desc("Additional directory to search headers in. Can be specified "
+                  "multiple times"),
+    whitelist());
+
+cl::alias additionalEntryPointsAlias("e", cl::desc("Alias for --other-entry"),
+                                     cl::aliasopt(additionalEntryPoints),
+                                     whitelist());
+cl::alias partialDisassemblyAlias("p", cl::desc("Alias for --partial"),
+                                  cl::aliasopt(partialDisassembly),
+                                  whitelist());
+cl::alias additionalPassesAlias("O", cl::desc("Alias for --opt"),
+                                cl::aliasopt(additionalPasses), whitelist());
+cl::alias inputIsModuleAlias("m", cl::desc("Alias for --module-in"),
+                             cl::aliasopt(inputIsModule), whitelist());
+cl::alias outputIsModuleAlias("n", cl::desc("Alias for --module-out"),
+                              cl::aliasopt(outputIsModule), whitelist());
+
+cl::opt<string> remillArch(
+    "arch", cl::Required,
+    cl::desc("Architecture of the code being translated. Valid architectures: "
+             "x86, amd64 (with or without `_avx` or `_avx512` appended), "
+             "aarch64, mips32, mips64"),
+    whitelist());
+cl::opt<string> remillOS(
+    "os", cl::Required,
+    cl::desc("Operating system name of the code being translated. Valid OSes: "
+             "linux, macos, windows."),
+    whitelist());
+
+template <int (*)()>  // templated to ensure multiple instatiation of the static
+                      // variables
+                      inline int optCount(const cl::list<bool>& list) {
+  static int count = 0;
+  static bool counted = false;
+  if (!counted) {
+    for (bool opt : list) {
+      count += opt ? 1 : -1;
+    }
+    counted = true;
+  }
+  return count;
+}
+
+inline int partialOptCount() {
+  return optCount<partialOptCount>(partialDisassembly);
+}
+
+inline int moduleInCount() { return optCount<moduleInCount>(inputIsModule); }
+
+inline int moduleOutCount() { return optCount<moduleOutCount>(outputIsModule); }
+
+void pruneOptionList(StringMap<cl::Option*>& list) {
+  for (auto& pair : list) {
+    if (!whitelist::isWhitelisted(*pair.second)) {
+      pair.second->setHiddenFlag(cl::ReallyHidden);
+    }
+  }
+}
+
+template <typename T>
+string errorOf(const ErrorOr<T>& error) {
+  return error.getError().message();
+}
+
+template <typename TAction>
+size_t forEachCall(Function* callee, unsigned stringArgumentIndex,
+                   TAction&& action) {
+  size_t count = 0;
+  for (Use& use : callee->uses()) {
+    if (auto call = dyn_cast<CallInst>(use.getUser())) {
+      unique_ptr<Instruction> eraseIfNecessary;
+      Value* operand = call->getOperand(stringArgumentIndex);
+      if (auto constant = dyn_cast<ConstantExpr>(operand)) {
+        eraseIfNecessary.reset(constant->getAsInstruction());
+        operand = eraseIfNecessary.get();
+      }
+
+      if (auto gep = dyn_cast<GetElementPtrInst>(operand))
+        if (auto global = dyn_cast<GlobalVariable>(gep->getOperand(0)))
+          if (auto dataArray =
+                  dyn_cast<ConstantDataArray>(global->getInitializer())) {
+            action(dataArray->getAsString().str());
+            count++;
+          }
+    }
+  }
+  return count;
+}
+
+bool refillEntryPoints(const TranslationContext& transl,
+                       const EntryPointRepository& entryPoints,
+                       map<uint64_t, SymbolInfo>& toVisit, size_t iterations) {
+  if (isExclusiveDisassembly() || (isPartialDisassembly() && iterations > 1)) {
+    return false;
+  }
+
+  for (uint64_t entryPoint : transl.getDiscoveredEntryPoints()) {
+    if (auto symbolInfo = entryPoints.getInfo(entryPoint)) {
+      toVisit.insert({entryPoint, *symbolInfo});
+    }
+  }
+  return !toVisit.empty();
+}
+
+class Main {
+  int argc;
+  char** argv;
+
+  LLVMContext llvm;
+  PythonContext python;
+  vector<Pass*> optimizeAndTransformPasses;
+
+  static void aliasAnalysisHooks(Pass& pass, Function& fn, AAResults& aar) {
+    if (auto prgmem =
+            pass.getAnalysisIfAvailable<ProgramMemoryAAWrapperPass>()) {
+      aar.addAAResult(prgmem->getResult());
+    }
+    if (auto params = pass.getAnalysisIfAvailable<ParameterRegistry>()) {
+      aar.addAAResult(params->getAAResult());
+    }
+  }
+
+  static legacy::PassManager createBasePassManager() {
+    legacy::PassManager pm;
+    pm.add(createTypeBasedAAWrapperPass());
+    pm.add(createScopedNoAliasAAWrapperPass());
+    pm.add(createBasicAAWrapperPass());
+    pm.add(createProgramMemoryAliasAnalysis());
+    return pm;
+  }
+
+  vector<Pass*> createPassesFromList(const vector<string>& passNames) {
+    vector<Pass*> result;
+    PassRegistry* pr = PassRegistry::getPassRegistry();
+    for (string passName : passNames) {
+      auto begin = passName.begin();
+      while (begin != passName.end()) {
+        if (isspace(*begin)) {
+          ++begin;
+        } else {
+          break;
+        }
+      }
+      passName.erase(passName.begin(), begin);
+
+      auto rbegin = passName.rbegin();
+      while (rbegin != passName.rend()) {
+        if (isspace(*rbegin)) {
+          ++rbegin;
+        } else {
+          break;
+        }
+      }
+      passName.erase(rbegin.base(), passName.end());
+
+      if (passName.size() > 0 && passName[0] != '#') {
+        auto ext = sys::path::extension(passName);
+        if (ext == ".py" || ext == ".pyc" || ext == ".pyo") {
+          if (auto passOrError = python.createPass(passName)) {
+            result.push_back(passOrError.get());
+          } else {
+            cerr << getProgramName() << ": couldn't load " << passName << ": "
+                 << errorOf(passOrError) << endl;
+            return vector<Pass*>();
+          }
+        } else if (const PassInfo* pi = pr->getPassInfo(passName)) {
+          result.push_back(pi->createPass());
+        } else {
+          cerr << getProgramName() << ": couldn't identify pass " << passName
+               << endl;
+          return vector<Pass*>();
+        }
+      }
+    }
+
+    if (result.size() == 0) {
+      errs() << getProgramName() << ": empty pass list\n";
+    }
+    return result;
+  }
+
+  vector<Pass*> interactivelyEditPassPipeline(
+      const string& editor, const vector<string>& basePasses) {
+    int fd;
+    SmallVector<char, 100> path;
+    if (auto errorCode = sys::fs::createTemporaryFile("fcd-pass-pipeline",
+                                                      "txt", fd, path)) {
+      errs() << getProgramName() << ": can't open temporary file for editing: "
+             << errorCode.message() << "\n";
+      return vector<Pass*>();
+    }
+
+    raw_fd_ostream passListOs(fd, true);
+    passListOs << "# Enter the name of the LLVM or fcd passes that you want to "
+                  "run on the module.\n";
+    passListOs << "# Files starting with a # symbol are ignored.\n";
+    passListOs << "# Names ending with .py are assumed to be Python scripts "
+                  "implementing passes.\n";
+    for (const string& passName : basePasses) {
+      passListOs << passName << '\n';
+    }
+    passListOs.flush();
+
+    // shell escape temporary path
+    string escapedPath;
+    escapedPath.reserve(path.size());
+    for (char c : path) {
+      if (c == '\'' || c == '\\') {
+        escapedPath.push_back('\\');
+      }
+      escapedPath.push_back(c);
+    }
+
+    string editCommand;
+    raw_string_ostream(editCommand) << editor << " '" << escapedPath << "'";
+    if (int errorCode = system(editCommand.c_str())) {
+      errs() << getProgramName()
+             << ": interactive pass pipeline: editor returned status code "
+             << errorCode << '\n';
+      return vector<Pass*>();
+    }
+
+    ifstream passListIs(path.data());
+    assert(static_cast<bool>(passListIs));
+
+    string inputLine;
+    vector<string> lines;
+    while (getline(passListIs, inputLine)) {
+      lines.push_back(inputLine);
+      inputLine.clear();
+    }
+    if (inputLine.size() != 0) {
+      lines.push_back(inputLine);
+    }
+
+    return createPassesFromList(lines);
+  }
+
+  vector<Pass*> readPassPipelineFromString(const string& argString) {
+    stringstream ss(argString, ios::in);
+    vector<string> passes;
+    while (ss) {
+      passes.emplace_back();
+      string& passName = passes.back();
+      ss >> passName;
+      if (passName.size() == 0 || passName[0] == '#') {
+        passes.pop_back();
+      }
+    }
+    auto result = createPassesFromList(passes);
+    if (result.size() == 0) {
+      errs() << getProgramName() << ": empty custom pass list\n";
+    }
+    return result;
+  }
+
+ public:
+  Main(int argc, char** argv) : argc(argc), argv(argv), python(argv[0]) {
+    (void)argc;
+    (void)this->argc;
+  }
+
+  string getProgramName() { return sys::path::stem(argv[0]); }
+  LLVMContext& getContext() { return llvm; }
+
+  ErrorOr<unique_ptr<Executable>> parseExecutable(
+      MemoryBuffer& executableCode) {
+    auto start =
+        reinterpret_cast<const uint8_t*>(executableCode.getBufferStart());
+    auto end = reinterpret_cast<const uint8_t*>(executableCode.getBufferEnd());
+    return Executable::parse(start, end);
+  }
+
+  ErrorOr<unique_ptr<Module>> generateAnnotatedModule(
+      Executable& executable, const string& moduleName = "fcd-out") {
+    x86_config config64 = {x86_isa64, 8, X86_REG_RIP, X86_REG_RSP, X86_REG_RBP};
+    TranslationContext transl(llvm, executable, config64, moduleName);
+
+    // Load headers here, since this is the earliest point where we have an
+    // executable and a module.
+    auto cDecls = HeaderDeclarations::create(
+        transl.get(), headerSearchPath.begin(), headerSearchPath.end(),
+        headers.begin(), headers.end(), frameworks.begin(), frameworks.end(),
+        errs());
+    if (!cDecls) {
+      return make_error_code(FcdError::Main_HeaderParsingError);
+    }
+
+    EntryPointRepository entryPoints;
+    entryPoints.addProvider(executable);
+    entryPoints.addProvider(*cDecls);
+
+    md::addIncludedFiles(transl.get(), cDecls->getIncludedFiles());
+
+    map<uint64_t, SymbolInfo> toVisit;
+    if (isFullDisassembly()) {
+      for (uint64_t address : entryPoints.getVisibleEntryPoints()) {
+        auto symbolInfo = entryPoints.getInfo(address);
+        assert(symbolInfo != nullptr);
+        toVisit.insert({symbolInfo->virtualAddress, *symbolInfo});
+      }
+    }
+
+    for (uint64_t address : unordered_set<uint64_t>(
+             additionalEntryPoints.begin(), additionalEntryPoints.end())) {
+      if (auto symbolInfo = entryPoints.getInfo(address)) {
+        toVisit.insert({symbolInfo->virtualAddress, *symbolInfo});
+      } else {
+        return make_error_code(FcdError::Main_EntryPointOutOfMappedMemory);
+      }
+    }
+
+    if (toVisit.size() == 0) {
+      return make_error_code(FcdError::Main_NoEntryPoint);
+    }
+
+    size_t iterations = 0;
+    do {
+      while (toVisit.size() > 0) {
+        auto iter = toVisit.begin();
+        auto functionInfo = iter->second;
+        toVisit.erase(iter);
+
+        if (functionInfo.name.size() > 0) {
+          transl.setFunctionName(functionInfo.virtualAddress,
+                                 functionInfo.name);
+        }
+
+        if (Function* fn = transl.createFunction(functionInfo.virtualAddress)) {
+          if (Function* cFunction =
+                  cDecls->prototypeForAddress(functionInfo.virtualAddress)) {
+            md::setFinalPrototype(*fn, *cFunction);
+          }
+        } else {
+          // Couldn't decompile, abort
+          return make_error_code(FcdError::Main_DecompilationError);
+        }
+      }
+      iterations++;
+    } while (refillEntryPoints(transl, entryPoints, toVisit, iterations));
+
+    // Perform early optimizations to make the module suitable for analysis
+    auto module = transl.take();
+    legacy::PassManager phaseOne = createBasePassManager();
+    phaseOne.add(createExternalAAWrapperPass(&Main::aliasAnalysisHooks));
+    phaseOne.add(createDeadCodeEliminationPass());
+    phaseOne.add(createInstructionCombiningPass());
+    phaseOne.add(createRegisterPointerPromotionPass());
+    phaseOne.add(createGVNPass());
+    phaseOne.add(createDeadStoreEliminationPass());
+    phaseOne.add(createInstructionCombiningPass());
+    phaseOne.add(createGlobalDCEPass());
+    phaseOne.run(*module);
+
+    // Annotate stubs before returning module
+    Function* jumpIntrin = module->getFunction("x86_jump_intrin");
+    vector<Function*> functions;
+    for (Function& fn : module->getFunctionList()) {
+      if (md::isPrototype(fn)) {
+        continue;
+      }
+
+      BasicBlock& entry = fn.getEntryBlock();
+      auto terminator = entry.getTerminator();
+      if (isa<UnreachableInst>(terminator)) {
+        if (auto prev = dyn_cast<CallInst>(terminator->getPrevNode()))
+          if (prev->getCalledFunction() == jumpIntrin)
+            if (auto load = dyn_cast<LoadInst>(prev->getOperand(2)))
+              if (auto constantExpr =
+                      dyn_cast<ConstantExpr>(load->getPointerOperand())) {
+                unique_ptr<Instruction> inst(constantExpr->getAsInstruction());
+                if (auto int2ptr = dyn_cast<IntToPtrInst>(inst.get())) {
+                  auto value = cast<ConstantInt>(int2ptr->getOperand(0));
+                  if (const StubInfo* stubTarget =
+                          executable.getStubTarget(value->getLimitedValue())) {
+                    if (Function* cFunction =
+                            cDecls->prototypeForImportName(stubTarget->name)) {
+                      md::setIsStub(fn);
+                      md::setFinalPrototype(fn, *cFunction);
+                    }
+
+                    // If we identified no function from the header file, this
+                    // gives the import its real
+                    // name. Otherwise, it'll prefix the name with some number.
+                    fn.setName(stubTarget->name);
+                  }
+                }
+              }
+      }
+    }
+    return move(module);
+  }
+
+  bool optimizeAndTransformModule(Module& module, raw_ostream& errorOutput,
+                                  Executable* executable = nullptr) {
+    PrettyStackTraceString optimize("Optimizing LLVM IR");
+
+    // Phase 3: make into functions with arguments, run codegen.
+    auto passManager = createBasePassManager();
+    passManager.add(new ExecutableWrapper(executable));
+    passManager.add(createParameterRegistryPass());
+    passManager.add(createExternalAAWrapperPass(&Main::aliasAnalysisHooks));
+    for (Pass* pass : optimizeAndTransformPasses) {
+      passManager.add(pass);
+    }
+    passManager.run(module);
+
 #ifdef FCD_DEBUG
-			if (verifyModule(module, &errorOutput))
-			{
-				// errors!
-				return false;
-			}
+    if (verifyModule(module, &errorOutput)) {
+      // errors!
+      return false;
+    }
 #endif
-			return true;
-		}
+    return true;
+  }
 
-		bool generateEquivalentPseudocode(Module& module, raw_ostream& output)
-		{
-			PrettyStackTraceString pseudocode("Generating pseudo-C output");
-			
-			// Run that module through the output pass
-			// UnwrapReturns happens after value propagation because value propagation doesn't know that calls
-			// are generally not safe to reorder.
-			AstBackEnd* backend = createAstBackEnd();
-			backend->addPass(new AstRemoveUndef);
-			backend->addPass(new AstConsecutiveCombiner);
-			backend->addPass(new AstNestedCombiner);
-			backend->addPass(new AstConsecutiveCombiner);
-			backend->addPass(new AstSimplifyExpressions);
-			backend->addPass(new AstMergeCongruentVariables);
-			backend->addPass(new AstConsecutiveCombiner);
-			backend->addPass(new AstNestedCombiner);
-			backend->addPass(new AstConsecutiveCombiner);
-			backend->addPass(new AstPrint(output, md::getIncludedFiles(module)));
-			backend->runOnModule(module);
-			return true;
-		}
-	
-		static void initializePasses()
-		{
-			auto& pr = *PassRegistry::getPassRegistry();
-			initializeCore(pr);
-			initializeVectorization(pr);
-			initializeIPO(pr);
-			initializeAnalysis(pr);
-			initializeTransformUtils(pr);
-			initializeInstCombine(pr);
-			initializeScalarOpts(pr);
-		
-			initializeParameterRegistryPass(pr);
-			initializeArgumentRecoveryPass(pr);
-		}
-		
-		bool prepareOptimizationPasses()
-		{
-			// Default passes
-			vector<string> passNames = {
-				"globaldce",
-				"fixindirects",
-				"argrec",
-				"sroa",
-				"intnarrowing",
-				"signext",
-				"instcombine",
-				"intops",
-				"simplifyconditions",
-				// <-- custom passes go here with the default pass pipeline
-				"instcombine",
-				"gvn",
-				"simplifycfg",
-				"instcombine",
-				"gvn",
-				"recoverstackframe",
-				"dse",
-				"sccp",
-				"simplifycfg",
-				"eliminatecasts",
-				"instcombine",
-				"memssadle",
-				"dse",
-				"instcombine",
-				"sroa",
-				"instcombine",
-				"globaldce",
-				"simplifycfg",
-			};
-			
-			if (customPassPipeline == "default")
-			{
-				if (additionalPasses.size() > 0)
-				{
-					auto extensionPoint = find(passNames.begin(), passNames.end(), "simplifyconditions") + 1;
-					passNames.insert(extensionPoint, additionalPasses.begin(), additionalPasses.end());
-				}
-				optimizeAndTransformPasses = createPassesFromList(passNames);
-			}
-			else if (customPassPipeline == "")
-			{
-				if (auto editor = getenv("EDITOR"))
-				{
-					optimizeAndTransformPasses = interactivelyEditPassPipeline(editor, passNames);
-				}
-				else
-				{
-					errs() << getProgramName() << ": environment has no EDITOR variable; pass pipeline can't be edited interactively\n";
-					return false;
-				}
-			}
-			else
-			{
-				optimizeAndTransformPasses = readPassPipelineFromString(customPassPipeline);
-			}
-			return optimizeAndTransformPasses.size() > 0;
-		}
-	};
+  bool generateEquivalentPseudocode(Module& module, raw_ostream& output) {
+    PrettyStackTraceString pseudocode("Generating pseudo-C output");
+
+    // Run that module through the output pass
+    // UnwrapReturns happens after value propagation because value propagation
+    // doesn't know that calls
+    // are generally not safe to reorder.
+    AstBackEnd* backend = createAstBackEnd();
+    backend->addPass(new AstRemoveUndef);
+    backend->addPass(new AstConsecutiveCombiner);
+    backend->addPass(new AstNestedCombiner);
+    backend->addPass(new AstConsecutiveCombiner);
+    backend->addPass(new AstSimplifyExpressions);
+    backend->addPass(new AstMergeCongruentVariables);
+    backend->addPass(new AstConsecutiveCombiner);
+    backend->addPass(new AstNestedCombiner);
+    backend->addPass(new AstConsecutiveCombiner);
+    backend->addPass(new AstPrint(output, md::getIncludedFiles(module)));
+    backend->runOnModule(module);
+    return true;
+  }
+
+  static void initializePasses() {
+    auto& pr = *PassRegistry::getPassRegistry();
+    initializeCore(pr);
+    initializeVectorization(pr);
+    initializeIPO(pr);
+    initializeAnalysis(pr);
+    initializeTransformUtils(pr);
+    initializeInstCombine(pr);
+    initializeScalarOpts(pr);
+
+    initializeParameterRegistryPass(pr);
+    initializeArgumentRecoveryPass(pr);
+  }
+
+  bool prepareOptimizationPasses() {
+    // Default passes
+    vector<string> passNames = {
+        "globaldce", "fixindirects", "argrec", "sroa", "intnarrowing",
+        "signext", "instcombine", "intops", "simplifyconditions",
+        // <-- custom passes go here with the default pass pipeline
+        "instcombine", "gvn", "simplifycfg", "instcombine", "gvn",
+        "recoverstackframe", "dse", "sccp", "simplifycfg", "eliminatecasts",
+        "instcombine", "memssadle", "dse", "instcombine", "sroa", "instcombine",
+        "globaldce", "simplifycfg",
+    };
+
+    if (customPassPipeline == "default") {
+      if (additionalPasses.size() > 0) {
+        auto extensionPoint =
+            find(passNames.begin(), passNames.end(), "simplifyconditions") + 1;
+        passNames.insert(extensionPoint, additionalPasses.begin(),
+                         additionalPasses.end());
+      }
+      optimizeAndTransformPasses = createPassesFromList(passNames);
+    } else if (customPassPipeline == "") {
+      if (auto editor = getenv("EDITOR")) {
+        optimizeAndTransformPasses =
+            interactivelyEditPassPipeline(editor, passNames);
+      } else {
+        errs() << getProgramName() << ": environment has no EDITOR variable; "
+                                      "pass pipeline can't be edited "
+                                      "interactively\n";
+        return false;
+      }
+    } else {
+      optimizeAndTransformPasses =
+          readPassPipelineFromString(customPassPipeline);
+    }
+    return optimizeAndTransformPasses.size() > 0;
+  }
+};
 }
 
-bool isFullDisassembly()
-{
-	return partialOptCount() < 1;
+bool isFullDisassembly() { return partialOptCount() < 1; }
+
+bool isPartialDisassembly() { return partialOptCount() == 1; }
+
+bool isExclusiveDisassembly() { return partialOptCount() > 1; }
+
+bool isEntryPoint(uint64_t vaddr) {
+  return any_of(additionalEntryPoints.begin(), additionalEntryPoints.end(),
+                [&](uint64_t entryPoint) { return vaddr == entryPoint; });
 }
 
-bool isPartialDisassembly()
-{
-	return partialOptCount() == 1;
-}
+int main(int argc, char** argv) {
+  EnablePrettyStackTrace();
+  sys::PrintStackTraceOnErrorSignal(argv[0]);
 
-bool isExclusiveDisassembly()
-{
-	return partialOptCount() > 1;
-}
+  pruneOptionList(cl::getRegisteredOptions());
+  cl::ParseCommandLineOptions(argc, argv, "native program decompiler");
 
-bool isEntryPoint(uint64_t vaddr)
-{
-	return any_of(additionalEntryPoints.begin(), additionalEntryPoints.end(), [&](uint64_t entryPoint)
-	{
-		return vaddr == entryPoint;
-	});
-}
+  FLAGS_os = remillOS;
+  FLAGS_arch = remillArch;
 
-int main(int argc, char** argv)
-{
-	EnablePrettyStackTrace();
-	sys::PrintStackTraceOnErrorSignal(argv[0]);
+  if (customPassPipeline != "default" && additionalPasses.size() > 0) {
+    errs() << sys::path::filename(argv[0]) << ": additional passes only "
+                                              "accepted when using the default "
+                                              "pipeline\n";
+    errs() << "Specify custom passes using the " << customPassPipeline.ArgStr
+           << " parameter\n";
+    return 1;
+  }
 
-	pruneOptionList(cl::getRegisteredOptions());
-	cl::ParseCommandLineOptions(argc, argv, "native program decompiler");
+  Main::initializePasses();
 
-	FLAGS_os = remillOS;
-  	FLAGS_arch = remillArch;
+  Main mainObj(argc, argv);
+  string program = mainObj.getProgramName();
 
-	if (customPassPipeline != "default" && additionalPasses.size() > 0)
-	{
-		errs() << sys::path::filename(argv[0]) << ": additional passes only accepted when using the default pipeline\n";
-		errs() << "Specify custom passes using the " << customPassPipeline.ArgStr << " parameter\n";
-		return 1;
-	}
-	
-	Main::initializePasses();
-	
-	Main mainObj(argc, argv);
-	string program = mainObj.getProgramName();
-	
-	// step 0: before even attempting anything, prepare optimization passes
-	// (the user won't be happy if we work for 5 minutes only to discover that the optimization passes don't load)
-	if (!mainObj.prepareOptimizationPasses())
-	{
-		return 1;
-	}
-	
-	unique_ptr<Executable> executable;
-	unique_ptr<Module> module;
-	
-	// step one: create annotated module from executable (or load it from .ll)
-	ErrorOr<unique_ptr<MemoryBuffer>> bufferOrError(nullptr);
-	if (moduleInCount())
-	{
-		PrettyStackTraceFormat parsingIR("Parsing IR from \"%s\"", inputFile.c_str());
-		
-		SMDiagnostic errors;
-		module = parseIRFile(inputFile, errors, mainObj.getContext());
-		if (!module)
-		{
-			errors.print(argv[0], errs());
-			return 1;
-		}
-	}
-	else
-	{
-		PrettyStackTraceFormat parsingIR("Parsing executable \"%s\"", inputFile.c_str());
-		
-		bufferOrError = MemoryBuffer::getFile(inputFile, -1, false);
-		if (!bufferOrError)
-		{
-			cerr << program << ": can't open " << inputFile << ": " << errorOf(bufferOrError) << endl;
-			return 1;
-		}
-		
-		auto executableOrError = mainObj.parseExecutable(*bufferOrError.get());
-		if (!executableOrError)
-		{
-			cerr << program << ": couldn't parse " << inputFile << ": " << errorOf(executableOrError) << endl;
-			return 1;
-		}
-		
-		executable = move(executableOrError.get());
-		string moduleName = sys::path::stem(inputFile);
-		auto moduleOrError = mainObj.generateAnnotatedModule(*executable, moduleName);
-		if (!moduleOrError)
-		{
-			cerr << program << ": couldn't build LLVM module out of " << inputFile << ": " << errorOf(moduleOrError) << endl;
-			return 1;
-		}
-		
-		module = move(moduleOrError.get());
-	}
-	
-	// Make sure that the module is legal
-	size_t errorCount = 0;
-	if (Function* assertionFailure = module->getFunction("x86_assertion_failure"))
-	{
-		errorCount += forEachCall(assertionFailure, 0, [](const string& message) {
-			cerr << "translation assertion failure: " << message << endl;
-		});
-	}
-	
-	if (errorCount > 0)
-	{
-		cerr << "incorrect or missing translations; cannot decompile" << endl;
-		return 1;
-	}
-	
-	// if we want module output, this is where we stop
-	if (moduleOutCount() == 1)
-	{
-		module->print(outs(), nullptr);
-		return 0;
-	}
-	
-	if (moduleInCount() < 2)
-	{
-		if (!mainObj.optimizeAndTransformModule(*module, errs(), executable.get()))
-		{
-			return 1;
-		}
-	}
-	
-	if (moduleOutCount() > 1)
-	{
-		module->print(outs(), nullptr);
-		return 0;
-	}
-	
-	// step three (final step): emit pseudocode
-	return mainObj.generateEquivalentPseudocode(*module, outs()) ? 0 : 1;
+  // step 0: before even attempting anything, prepare optimization passes
+  // (the user won't be happy if we work for 5 minutes only to discover that the
+  // optimization passes don't load)
+  if (!mainObj.prepareOptimizationPasses()) {
+    return 1;
+  }
+
+  unique_ptr<Executable> executable;
+  unique_ptr<Module> module;
+
+  // step one: create annotated module from executable (or load it from .ll)
+  ErrorOr<unique_ptr<MemoryBuffer>> bufferOrError(nullptr);
+  if (moduleInCount()) {
+    PrettyStackTraceFormat parsingIR("Parsing IR from \"%s\"",
+                                     inputFile.c_str());
+
+    SMDiagnostic errors;
+    module = parseIRFile(inputFile, errors, mainObj.getContext());
+    if (!module) {
+      errors.print(argv[0], errs());
+      return 1;
+    }
+  } else {
+    PrettyStackTraceFormat parsingIR("Parsing executable \"%s\"",
+                                     inputFile.c_str());
+
+    bufferOrError = MemoryBuffer::getFile(inputFile, -1, false);
+    if (!bufferOrError) {
+      cerr << program << ": can't open " << inputFile << ": "
+           << errorOf(bufferOrError) << endl;
+      return 1;
+    }
+
+    auto executableOrError = mainObj.parseExecutable(*bufferOrError.get());
+    if (!executableOrError) {
+      cerr << program << ": couldn't parse " << inputFile << ": "
+           << errorOf(executableOrError) << endl;
+      return 1;
+    }
+
+    executable = move(executableOrError.get());
+    string moduleName = sys::path::stem(inputFile);
+    auto moduleOrError =
+        mainObj.generateAnnotatedModule(*executable, moduleName);
+    if (!moduleOrError) {
+      cerr << program << ": couldn't build LLVM module out of " << inputFile
+           << ": " << errorOf(moduleOrError) << endl;
+      return 1;
+    }
+
+    module = move(moduleOrError.get());
+  }
+
+  // Make sure that the module is legal
+  size_t errorCount = 0;
+  if (Function* assertionFailure =
+          module->getFunction("x86_assertion_failure")) {
+    errorCount += forEachCall(assertionFailure, 0, [](const string& message) {
+      cerr << "translation assertion failure: " << message << endl;
+    });
+  }
+
+  if (errorCount > 0) {
+    cerr << "incorrect or missing translations; cannot decompile" << endl;
+    return 1;
+  }
+
+  // if we want module output, this is where we stop
+  if (moduleOutCount() == 1) {
+    module->print(outs(), nullptr);
+    return 0;
+  }
+
+  if (moduleInCount() < 2) {
+    if (!mainObj.optimizeAndTransformModule(*module, errs(),
+                                            executable.get())) {
+      return 1;
+    }
+  }
+
+  if (moduleOutCount() > 1) {
+    module->print(outs(), nullptr);
+    return 0;
+  }
+
+  // step three (final step): emit pseudocode
+  return mainObj.generateEquivalentPseudocode(*module, outs()) ? 0 : 1;
 }

--- a/fcd/main.cpp
+++ b/fcd/main.cpp
@@ -19,7 +19,6 @@
 #include "params_registry.h"
 #include "translation_context.h"
 
-#include <glog/logging.h>
 #include <gflags/gflags.h>
 
 #include <llvm/Analysis/AliasAnalysis.h>
@@ -675,18 +674,12 @@ int main(int argc, char** argv)
 {
 	EnablePrettyStackTrace();
 	sys::PrintStackTraceOnErrorSignal(argv[0]);
-	google::InitGoogleLogging(argv[0]);
 
 	pruneOptionList(cl::getRegisteredOptions());
 	cl::ParseCommandLineOptions(argc, argv, "native program decompiler");
 
 	FLAGS_os = remillOS;
-	CHECK(!FLAGS_os.empty())
-    	<< "Must specify an operating system name to --os.";
-
   	FLAGS_arch = remillArch;
-	CHECK(!FLAGS_arch.empty())
-    	<< "Must specify a machine code architecture name to --arch.";
 
 	if (customPassPipeline != "default" && additionalPasses.size() > 0)
 	{

--- a/fcd/main.cpp
+++ b/fcd/main.cpp
@@ -213,7 +213,7 @@ size_t forEachCall(Function* callee, unsigned stringArgumentIndex,
 bool refillEntryPoints(const TranslationContext& transl,
                        const EntryPointRepository& entryPoints,
                        map<uint64_t, SymbolInfo>& toVisit, size_t iterations) {
-  if (isExclusiveDisassembly() || (isPartialDisassembly() && iterations > 2)) {
+  if (isExclusiveDisassembly() || (isPartialDisassembly() && iterations > 1)) {
     return false;
   }
 

--- a/tests/decompiled-test.c
+++ b/tests/decompiled-test.c
@@ -1,0 +1,85 @@
+void _init(uint64_t rip)
+{
+	if (*(uint64_t*)0x600ff8 != 0)
+	{
+		__gmon_start__(4195261);
+	}
+	return;
+}
+void printf(uint64_t rip)
+{
+	__indirect_jump(*(uint64_t*)0x601018);
+}
+void __libc_start_main(uint64_t rip)
+{
+	__indirect_jump(*(uint64_t*)0x601020);
+}
+void __gmon_start__(uint64_t rip)
+{
+	__indirect_jump(*(uint64_t*)0x600ff8);
+}
+void _start(uint64_t rip, uint64_t rsp, uint64_t rdx)
+{
+	*(uint64_t*)(rsp - 8) = rip;
+	uint64_t anon1 = rsp & 0xfffffffffffffff0;
+	*(uint64_t*)(anon1 - 16) = anon1 - 8;
+	__libc_start_main(4195385);
+	__builtin_trap();
+}
+void deregister_tm_clones(uint64_t rip)
+{
+	return;
+}
+void register_tm_clones(uint64_t rip)
+{
+	return;
+}
+void __do_global_dtors_aux(uint64_t rip)
+{
+	uint8_t* anon1 = (uint8_t*)0x601038;
+	if (*anon1 == 0)
+	{
+		deregister_tm_clones(4195538);
+		*anon1 = 1;
+	}
+	return;
+}
+void frame_dummy(uint64_t rip)
+{
+	return;
+}
+void main(uint64_t rip, uint64_t rsp)
+{
+	uint64_t phi_in1;
+	*(uint64_t*)(rsp - 8) = rip;
+	*(uint32_t*)(rsp - 20) = 0;
+	*(uint64_t*)(rsp - 32) = 6295612;
+	printf(4195657);
+	*(uint32_t*)(rsp - 36) = 6295552;
+	if ((*(uint32_t*)0x60103c & 1) == 0)
+	{
+		printf(4195696);
+		phi_in1 = -40;
+	}
+	else 
+	{
+		printf(4195721);
+		phi_in1 = -44;
+	}
+	*(uint32_t*)(phi_in1 + rsp) = 6295552;
+	return;
+}
+void __libc_csu_init(uint64_t rip, uint64_t rdi, uint64_t rsi, uint64_t rdx)
+{
+	_init(4195793);
+	(*(void(**)(uint64_t, uint64_t, uint64_t))0x600e10)(rdi & 0xffffffff, rsi, rdx);
+	return;
+}
+void __libc_csu_fini(uint64_t rip)
+{
+	return;
+}
+void _fini(uint64_t rip)
+{
+	return;
+}

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+unsigned a = 0;
+
+int main(void)
+{
+    unsigned *b = &a;
+    
+    printf("Global variable 'a' of value %u at address %p is ", a, b);
+    if (a % 2 == 0)
+        printf("even.\n");
+    else
+        printf("odd.\n");
+    
+    return 0;
+}


### PR DESCRIPTION
This PR makes modifications to fcd's CMake files so that fcd is able to be built as a subproject of Remill, much like McSema. The idea is to clone fcd into remill/tools and build it alongside Remill. The PR also adds the `--os` and `--arch` flag support to fcd, so that it can be linked against Remill and as a start to deeper modifications of fcd to accomodate Remill.