### PR TITLE
Milestone 5: Replacement of `__remill*` intrinsics

### DIFF
--- a/fcd/codegen/translation_context_remill.cpp
+++ b/fcd/codegen/translation_context_remill.cpp
@@ -37,6 +37,7 @@
 #include "fcd/pass_argrec_remill.h"
 #include "fcd/pass_asaa.h"
 #include "fcd/pass_stackrec_remill.h"
+#include "fcd/pass_intrinsics_remill.h"
 
 namespace fcd {
 namespace {
@@ -602,6 +603,7 @@ void RemillTranslationContext::FinalizeModule() {
   // pm2.add(llvm::createReassociatePass());
   pm2.add(llvm::createDeadStoreEliminationPass());
   pm2.add(llvm::createDeadCodeEliminationPass());
+  pm2.add(createRemillFixIntrinsicsPass());
   // pm2.add(llvm::createInstructionCombiningPass());
   // pm2.add(llvm::createVerifierPass());
   pm2.run(*module);

--- a/fcd/pass_intrinsics_remill.cpp
+++ b/fcd/pass_intrinsics_remill.cpp
@@ -31,7 +31,6 @@ namespace fcd {
 
 namespace {
 
-static const char *sPrefix;
 static llvm::Module *sModule;
 
 static std::string TrimPrefix(std::string pref, std::string str) {
@@ -60,7 +59,6 @@ char RemillFixIntrinsics::ID = 0;
 
 RemillFixIntrinsics::RemillFixIntrinsics(void)
     : ModulePass(RemillFixIntrinsics::ID) {
-  sPrefix = cPrefix;
 }
 
 void RemillFixIntrinsics::getAnalysisUsage(llvm::AnalysisUsage &usage) const {}
@@ -139,7 +137,7 @@ llvm::ModulePass *createRemillFixIntrinsicsPass(void) {
   return new RemillFixIntrinsics;
 }
 
-static llvm::RegisterPass<RemillFixIntrinsics> remill_stackrec(
+static llvm::RegisterPass<RemillFixIntrinsics> remill_intrinsics(
     "remill_intrinsics", "Remill's Intrinsics Cleanup", true, false);
 
 }  // namespace fcd

--- a/fcd/pass_intrinsics_remill.cpp
+++ b/fcd/pass_intrinsics_remill.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/InstIterator.h>
+
+#include <map>
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+#include "remill/BC/Util.h"
+
+#include "fcd/pass_intrinsics_remill.h"
+
+namespace fcd {
+
+namespace {
+
+static const char *sPrefix;
+
+}  // namespace
+
+char RemillFixIntrinsics::ID = 0;
+
+RemillFixIntrinsics::RemillFixIntrinsics(void)
+    : ModulePass(RemillFixIntrinsics::ID) {
+  sPrefix = cPrefix;
+}
+
+void RemillFixIntrinsics::getAnalysisUsage(llvm::AnalysisUsage &usage) const {}
+
+bool RemillFixIntrinsics::runOnModule(llvm::Module &module) {
+  return true;
+}
+
+llvm::ModulePass *createRemillFixIntrinsicsPass(void) {
+  return new RemillFixIntrinsics;
+}
+
+static llvm::RegisterPass<RemillFixIntrinsics> remill_stackrec(
+    "remill_intrinsics", "Remill's Intrinsics Cleanup", true, false);
+
+}  // namespace fcd
+
+using namespace llvm;
+using RemillFixIntrinsics = fcd::RemillFixIntrinsics;
+INITIALIZE_PASS(RemillFixIntrinsics, "remill_intrinsics",
+                "Remill's Intrinsics Cleanup", true, false)

--- a/fcd/pass_intrinsics_remill.h
+++ b/fcd/pass_intrinsics_remill.h
@@ -23,9 +23,6 @@
 namespace fcd {
 
 class RemillFixIntrinsics: public llvm::ModulePass {
- private:
-  const char *cPrefix = "__fcd";
-
  public:
   static char ID;
 

--- a/fcd/pass_intrinsics_remill.h
+++ b/fcd/pass_intrinsics_remill.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FCD_PASS_INTRINSICS_REMILL_H_
+#define FCD_PASS_INTRINSICS_REMILL_H_
+
+#include <llvm/Analysis/Passes.h>
+#include <llvm/IR/Module.h>
+
+namespace fcd {
+
+class RemillFixIntrinsics: public llvm::ModulePass {
+ private:
+  const char *cPrefix = "fixintrinsics_";
+
+ public:
+  static char ID;
+
+  RemillFixIntrinsics(void);
+
+  void getAnalysisUsage(llvm::AnalysisUsage &usage) const override;
+  bool runOnModule(llvm::Module &module) override;
+};
+
+llvm::ModulePass *createRemillFixIntrinsicsPass(void);
+}  // namespace fcd
+
+namespace llvm {
+void initializeRemillFixIntrinsicsPass(PassRegistry &);
+}
+
+#endif  // FCD_PASS_INTRINSICS_REMILL_H_

--- a/fcd/pass_intrinsics_remill.h
+++ b/fcd/pass_intrinsics_remill.h
@@ -24,7 +24,7 @@ namespace fcd {
 
 class RemillFixIntrinsics: public llvm::ModulePass {
  private:
-  const char *cPrefix = "fixintrinsics_";
+  const char *cPrefix = "__fcd";
 
  public:
   static char ID;


### PR DESCRIPTION
This PR replaces calls to `__remill*` intrinsics with calls to new `__fcd*` intrinsics. The `__fcd*` intrinsics are identical to their `__remill*` counterparts in all but the fact that they don't require Remill's `State` and `Memory` pointers as arguments.

This should clean up the resulting C pseudocode of computations over the `State` structure which shouldn't be present in "high-level" C pseudocode. Also resolves crashes in pseudocode generation on some tests from `fcd/tests/`.

Resolves #22 