### PR TITLE
Misc fixes

### DIFF
--- a/fcd/ast/ast_context.cpp
+++ b/fcd/ast/ast_context.cpp
@@ -173,7 +173,10 @@ public:
 		
 		if (auto expression = dyn_cast<ConstantExpr>(&constant))
 		{
-			return ctx.uncachedExpressionFor(*expression->getAsInstruction());
+      auto inst = expression->getAsInstruction();
+      auto res = ctx.uncachedExpressionFor(*inst);
+      inst->deleteValue();
+      return res;
 		}
 		
 		if (auto structure = dyn_cast<ConstantStruct>(&constant))

--- a/fcd/ast/ast_context.h
+++ b/fcd/ast/ast_context.h
@@ -162,7 +162,7 @@ public:
 		return allocate<true, TernaryExpression>(3, cond, ifTrue, ifFalse);
 	}
 	
-	NumericExpression* numeric(const IntegerExpressionType& type, uint64_t ui)
+    NumericExpression* numeric(const IntegerExpressionType& type, llvm::APInt ui)
 	{
 		return allocate<false, NumericExpression>(0, type, ui);
 	}

--- a/fcd/ast/expressions.cpp
+++ b/fcd/ast/expressions.cpp
@@ -269,7 +269,7 @@ bool NumericExpression::operator==(const Expression& that) const
 {
 	if (auto token = llvm::dyn_cast<NumericExpression>(&that))
 	{
-		return this->ui64 == token->ui64;
+		return this->value == token->value;
 	}
 	return false;
 }

--- a/fcd/ast/expressions.h
+++ b/fcd/ast/expressions.h
@@ -17,6 +17,7 @@
 #include "not_null.h"
 
 #include <llvm/ADT/iterator_range.h>
+#include <llvm/ADT/APInt.h>
 
 #include <string>
 
@@ -312,29 +313,20 @@ public:
 struct NumericExpression final : public Expression
 {
 	const IntegerExpressionType& expressionType;
-	union
-	{
-		int64_t si64;
-		uint64_t ui64;
-	};
+    llvm::APInt value;
 	
 	static bool classof(const ExpressionUser* node)
 	{
 		return node->getUserType() == Numeric;
 	}
 	
-	NumericExpression(AstContext& ctx, unsigned uses, const IntegerExpressionType& type, uint64_t ui)
-	: Expression(Numeric, ctx, uses), expressionType(type), ui64(ui)
+	NumericExpression(AstContext& ctx, unsigned uses, const IntegerExpressionType& type, llvm::APInt val)
+	: Expression(Numeric, ctx, uses), expressionType(type), value(val)
 	{
 		assert(uses == 0);
+        assert(value.getBitWidth() == expressionType.getBits());
 	}
-	
-	NumericExpression(AstContext& ctx, unsigned uses, const IntegerExpressionType& type, int64_t si)
-	: Expression(Numeric, ctx, uses), expressionType(type), si64(si)
-	{
-		assert(uses == 0);
-	}
-	
+		
 	virtual const IntegerExpressionType& getExpressionType(AstContext&) const override { return expressionType; }
 	virtual bool operator==(const Expression& that) const override;
 };

--- a/fcd/ast/pass_backend.cpp
+++ b/fcd/ast/pass_backend.cpp
@@ -851,7 +851,7 @@ bool AstBackEnd::runOnModule(llvm::Module &m)
 	}
 	
 	// sort outputNodes by virtual address, then by name
-	sort(outputNodes.begin(), outputNodes.end(), [](unique_ptr<FunctionNode>& a, unique_ptr<FunctionNode>& b)
+	std::sort(outputNodes.begin(), outputNodes.end(), [](unique_ptr<FunctionNode>& a, unique_ptr<FunctionNode>& b)
 	{
 		auto virtA = getVirtualAddress(*a);
 		auto virtB = getVirtualAddress(*b);

--- a/fcd/ast/pass_simplifyexpressions.cpp
+++ b/fcd/ast/pass_simplifyexpressions.cpp
@@ -255,7 +255,7 @@ namespace
 			
 			if (auto addressOf = match(subscript.getPointer(), UnaryOperatorExpression::AddressOf))
 			if (auto constantIndex = dyn_cast<NumericExpression>(subscript.getIndex()))
-			if (constantIndex->ui64 == 0)
+			if (constantIndex->value == 0)
 			{
 				subscript.replaceAllUsesWith(addressOf->getOperand());
 				subscript.dropAllReferences();

--- a/fcd/ast/pre_ast_cfg.cpp
+++ b/fcd/ast/pre_ast_cfg.cpp
@@ -169,7 +169,7 @@ void PreAstContext::generateBlocks(Function& fn)
 					{
 						auto bits = static_cast<unsigned short>(caseValue->getType()->getIntegerBitWidth());
 						const IntegerExpressionType& type = ctx.getIntegerType(false, bits);
-						Expression* numericConstant = ctx.numeric(type, caseValue->getLimitedValue());
+						Expression* numericConstant = ctx.numeric(type, caseValue->getValue());
 						caseCondition = ctx.nary(NAryOperatorExpression::Equal, testVariable, numericConstant);
 					}
 					if (dest == &bbRef)
@@ -210,7 +210,7 @@ PreAstBasicBlock& PreAstContext::createRedirectorBlock(ArrayRef<PreAstBasicBlock
 		auto iter = caseConditions.find(edge->to);
 		if (iter == caseConditions.end())
 		{
-			Expression* numericConstant = ctx.numeric(ctx.getIntegerType(false, 32), caseConditions.size());
+            Expression* numericConstant = ctx.numeric(ctx.getIntegerType(false, 32), llvm::APInt(32, caseConditions.size()));
 			auto condition = ctx.nary(NAryOperatorExpression::Equal, sythesizedVariable, numericConstant);
 			iter = caseConditions.insert({edge->to, condition}).first;
 			

--- a/fcd/ast/print.cpp
+++ b/fcd/ast/print.cpp
@@ -440,7 +440,7 @@ void StatementPrintVisitor::visitNumeric(const NumericExpression& numeric)
 	// 2- the parent expression is is a bitwise operator and the number is greater than 9.
 	if (auto nary = dyn_cast_or_null<NAryOperatorExpression>(parentExpression))
 	{
-		if (numeric.ui64 > 9)
+		if (numeric.value.ugt(9))
 		{
 			switch (nary->getType())
 			{
@@ -461,11 +461,11 @@ void StatementPrintVisitor::visitNumeric(const NumericExpression& numeric)
 	
 	if (formatAsHex)
 	{
-		(os << "0x").write_hex(numeric.ui64);
+		os << "0x" << numeric.value.toString(16, false);
 	}
 	else
 	{
-		os << numeric.si64;
+        os << numeric.value.toString(10, true);
 	}
 }
 

--- a/fcd/ast/print_item.cpp
+++ b/fcd/ast/print_item.cpp
@@ -28,6 +28,8 @@ namespace
 	}
 }
 
+PrintableItem::~PrintableItem() {}
+
 void PrintableItem::dump() const
 {
 	print(errs(), 0);

--- a/fcd/ast/print_item.h
+++ b/fcd/ast/print_item.h
@@ -34,6 +34,7 @@ private:
 	PrintableScope* parent;
 	
 public:
+	virtual ~PrintableItem();
 	PrintableItem(Type type, PrintableScope* parent)
 	: discriminant(type), parent(parent)
 	{

--- a/fcd/codegen/translation_context_remill.cpp
+++ b/fcd/codegen/translation_context_remill.cpp
@@ -279,11 +279,9 @@ RemillTranslationContext::RemillTranslationContext(llvm::LLVMContext &ctx,
   target_arch = remill::GetTargetArch();
   module = std::unique_ptr<llvm::Module>(remill::LoadTargetSemantics(&ctx));
   target_arch->PrepareModule(module);
-  auto word_type = llvm::Type::getIntNTy(
-      module->getContext(), static_cast<unsigned>(target_arch->address_size));
+  
   intrinsics = std::make_unique<remill::IntrinsicTable>(module.get());
-  lifter =
-      std::make_unique<remill::InstructionLifter>(word_type, intrinsics.get());
+  lifter = std::make_unique<remill::InstructionLifter>(target_arch, intrinsics.get());
 }
 
 uint64_t RemillTranslationContext::FindFunctionAddr(llvm::Function *func) {

--- a/fcd/codegen/translation_context_remill.cpp
+++ b/fcd/codegen/translation_context_remill.cpp
@@ -557,6 +557,7 @@ const StubInfo *RemillTranslationContext::GetStubInfo(
         if (auto int2ptr = llvm::dyn_cast<llvm::IntToPtrInst>(inst)) {
           addr = llvm::dyn_cast<llvm::ConstantInt>(int2ptr->getOperand(0));
         }
+        inst->deleteValue();
       } else {
         addr = llvm::dyn_cast<llvm::ConstantInt>(read_op);
       }

--- a/fcd/codegen/translation_context_remill.cpp
+++ b/fcd/codegen/translation_context_remill.cpp
@@ -23,6 +23,8 @@
 #include <llvm/IR/Verifier.h>
 
 #include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Transforms/Utils.h>
+#include <llvm/Transforms/InstCombine/InstCombine.h>
 
 #include <sstream>
 #include <string>

--- a/fcd/codegen/translation_context_remill.cpp
+++ b/fcd/codegen/translation_context_remill.cpp
@@ -36,10 +36,7 @@
 #include "fcd/compat/AnalysisPasses.h"
 
 #include "fcd/codegen/translation_context_remill.h"
-#include "fcd/pass_argrec_remill.h"
-#include "fcd/pass_asaa.h"
-#include "fcd/pass_stackrec_remill.h"
-#include "fcd/pass_intrinsics_remill.h"
+#include "fcd/passes.h"
 
 namespace fcd {
 namespace {
@@ -579,6 +576,7 @@ void RemillTranslationContext::FinalizeModule() {
   
   llvm::legacy::PassManager phase_one;
   phase_one.add(llvm::createAlwaysInlinerLegacyPass());
+  phase_one.add(createSignExtPass());
   phase_one.add(createRemillArgumentRecoveryPass());
   phase_one.add(llvm::createPromoteMemoryToRegisterPass());
   phase_one.add(llvm::createReassociatePass());

--- a/fcd/pass_argrec_remill.cpp
+++ b/fcd/pass_argrec_remill.cpp
@@ -383,11 +383,11 @@ bool RemillArgumentRecovery::runOnModule(llvm::Module &module) {
     llvm::Function* new_func = func_pair.second;
     auto is_old_func = [&](llvm::Function* f) { return funcs.find(f) != funcs.end(); };
     UpdateCalls(old_func, new_func, cc, is_old_func);
-    for (auto &arg : new_func->args()) {
-      auto arg_name = TrimPrefix(arg.getName());
-      auto var = remill::FindVarInFunction(new_func, arg_name);
-      arg.takeName(var);
-    }
+//    for (auto &arg : new_func->args()) {
+//      auto arg_name = TrimPrefix(arg.getName());
+//      auto var = remill::FindVarInFunction(new_func, arg_name);
+//      arg.takeName(var);
+//    }
     assert(old_func->use_empty());
     old_func->replaceAllUsesWith(llvm::UndefValue::get(old_func->getType()));
     new_func->takeName(old_func);

--- a/fcd/pass_argrec_remill.cpp
+++ b/fcd/pass_argrec_remill.cpp
@@ -339,12 +339,13 @@ static void ConvertRemillArgsToLocals(llvm::Function *func) {
 
   ir.SetInsertPoint(loc_mem);
 
-  auto pc_type = remill::AddressType(module);
+  //auto pc_type = remill::AddressType(module);
   auto arg_pc = remill::NthArgument(func, remill::kPCArgNum);
-  auto loc_pc = ir.CreateAlloca(pc_type, nullptr, "loc_pc");
-  arg_pc->replaceAllUsesWith(loc_pc);
+  assert(arg_pc->use_empty());
+//  auto loc_pc = ir.CreateAlloca(pc_type, nullptr, "loc_pc");
+//  arg_pc->replaceAllUsesWith(loc_pc);
 
-  ir.SetInsertPoint(loc_pc);
+//  ir.SetInsertPoint(loc_pc);
 
   auto state_type = remill::StatePointerType(module)->getElementType();
   auto arg_state = remill::NthArgument(func, remill::kStatePointerArgNum);

--- a/fcd/pass_argrec_remill.cpp
+++ b/fcd/pass_argrec_remill.cpp
@@ -115,51 +115,25 @@ static std::unordered_set<const char *> RegisterAliasSet(const char *reg) {
   return result;
 }
 
-static std::unordered_set<llvm::User *> UsersOfVar(llvm::Function *func,
-                                                   llvm::Value *var) {
-  std::unordered_set<llvm::User *> result;
-  if (var->hasNUsesOrMore(2)) {
+static std::unordered_map<llvm::User*, const char *> UsesOfReg(llvm::Function *func, const char *reg) {
+  std::unordered_map<llvm::User*, const char *> result;
+  for (auto alias : RegisterAliasSet(reg)) {
+    auto var = remill::FindVarInFunction(func, alias);
     for (auto var_user : var->users()) {
-      if (auto addr = llvm::dyn_cast<llvm::LoadInst>(var_user)) {
-        for (auto addr_user : addr->users()) {
-          result.insert(addr_user);
-        }
-      }
+      result[var_user] = alias;
     }
   }
   return result;
 }
 
-template <typename T>
-static llvm::User *FirstUserOfVar(llvm::Function *func, llvm::Value *var,
-                                  T &instruction_list) {
-  auto users = UsersOfVar(func, var);
-  if (!users.empty()) {
-    for (auto &inst : instruction_list) {
-      if (users.count(&inst) > 0) {
-        return &inst;
-      }
-    }
-  }
-  return nullptr;
-}
-
-template <typename T>
-static std::pair<llvm::User *, const char *> FirstUserOfReg(
-    llvm::Function *func, const char *reg, T &instruction_list) {
-  std::unordered_map<llvm::User *, const char *> users;
-  for (auto alias : RegisterAliasSet(reg)) {
-    auto var = remill::FindVarInFunction(func, alias);
-    if (auto user = FirstUserOfVar(func, var, instruction_list)) {
-      users[user] = alias;
-    }
-  }
-
-  if (!users.empty()) {
-    for (auto &inst : instruction_list) {
-      auto it = users.find(&inst);
-      if (it != users.end()) {
-        return *it;
+template <typename InstType, typename T>
+static std::pair<InstType *, const char *> FirstRegUser(llvm::Function *func, const char *reg, T &instruction_list) {
+  auto uses = UsesOfReg(func, reg);
+  for (auto &inst : instruction_list) {
+    if (auto typedInst = llvm::dyn_cast<InstType>(&inst)) {
+      auto it = uses.find(&inst);
+      if (it != uses.end())  {
+        return std::make_pair(typedInst, it->second);
       }
     }
   }
@@ -188,11 +162,9 @@ static llvm::Type *RecoverRetType(llvm::Function *func, CallingConvention &cc) {
   for (auto block : TerminalBlocksOf(func)) {
     auto ilist = llvm::make_range(block->rbegin(), block->rend());
     for (auto reg : ret_regs) {
-      auto user = FirstUserOfReg(func, reg, ilist);
+      auto user = FirstRegUser<llvm::StoreInst>(func, reg, ilist);
       if (user.first != nullptr) {
-        if (auto store = llvm::dyn_cast<llvm::StoreInst>(user.first)) {
-          found_types.insert(store->getValueOperand()->getType());
-        }
+        found_types.insert(user.first->getValueOperand()->getType());
       }
     }
   }
@@ -213,7 +185,7 @@ static void LoadReturnRegToRetInsts(llvm::Function *func,
     for (auto block : TerminalBlocksOf(func)) {
       auto term = block->getTerminator();
       ir.SetInsertPoint(term);
-      auto val = ir.CreateLoad(ir.CreateLoad(var));
+      auto val = ir.CreateLoad(var);
       ir.CreateRet(val);
       term->eraseFromParent();
     }
@@ -250,7 +222,7 @@ static void UpdateCalls(llvm::Function *old_func, llvm::Function *new_func,
       for (auto &arg : new_func->args()) {
         auto name = TrimPrefix(arg.getName().str());
         auto arg_var = remill::FindVarInFunction(caller, name);
-        params.push_back(ir.CreateLoad(ir.CreateLoad(arg_var)));
+        params.push_back(ir.CreateLoad(arg_var));
       }
 
       auto new_call = ir.CreateCall(new_func, params);
@@ -259,7 +231,7 @@ static void UpdateCalls(llvm::Function *old_func, llvm::Function *new_func,
       if (!ret_type->isVoidTy()) {
         auto ret_reg = cc.ReturnRegForType(ret_type);
         auto ret_var = remill::FindVarInFunction(caller, ret_reg);
-        ir.CreateStore(new_call, ir.CreateLoad(ret_var));
+        ir.CreateStore(new_call, ret_var);
       }
       old_call->replaceAllUsesWith(
           old_call->getArgOperand(remill::kMemoryPointerArgNum));
@@ -270,30 +242,21 @@ static void UpdateCalls(llvm::Function *old_func, llvm::Function *new_func,
 
 static llvm::Function *DeclareParametrizedFunc(llvm::Function *func,
                                                CallingConvention &cc) {
+  
   std::vector<const char *> used_regs;
+  std::vector<llvm::Type *> params;
+  
   // Get parameter regs from the callconv. Also add the stack pointer reg,
   // since it's used to access parameters passed by stack. Also add aliases.
   auto cc_regs = cc.ParamRegs();
   auto ilist = llvm::make_range(llvm::inst_begin(func), llvm::inst_end(func));
   cc_regs.insert(cc_regs.begin(), cc.StackPointerVarName());
   for (auto reg : cc_regs) {
-    auto user = FirstUserOfReg(func, reg, ilist);
-    if (user.first != nullptr) {
-      if (llvm::isa<llvm::LoadInst>(user.first)) {
-        used_regs.push_back(user.second);
-      }
+    auto alias = FirstRegUser<llvm::LoadInst>(func, reg, ilist);
+    if (alias.first != nullptr) {
+      used_regs.push_back(alias.second);
+      params.push_back(alias.first->getType());
     }
-  }
-
-  // Gather parameter types from register variable alloca's
-  std::vector<llvm::Type *> params;
-  for (auto reg : used_regs) {
-    auto var = remill::FindVarInFunction(func, reg);
-    auto inst = llvm::dyn_cast<llvm::AllocaInst>(var);
-    CHECK(inst != nullptr);
-    auto type = llvm::dyn_cast<llvm::PointerType>(inst->getAllocatedType());
-    CHECK(type != nullptr);
-    params.push_back(type->getElementType());
   }
 
   auto ret = RecoverRetType(func, cc);
@@ -311,8 +274,9 @@ static llvm::Function *DeclareParametrizedFunc(llvm::Function *func,
     std::stringstream cc_arg_name;
     cc_arg_name << sPrefix << used_regs[arg.getArgNo()];
     arg.setName(cc_arg_name.str());
+    removeAttr(arg, llvm::Attribute::Dereferenceable);
   }
-
+  
   return cc_func;
 }
 
@@ -321,8 +285,7 @@ static void StoreRegArgsToLocals(llvm::Function *func) {
   for (auto &arg : func->args()) {
     auto name = TrimPrefix(arg.getName().str());
     auto var = remill::FindVarInFunction(func, name);
-    auto ptr = ir.CreateLoad(var);
-    ir.CreateStore(&arg, ptr);
+    ir.CreateStore(&arg, var);
   }
 }
 
@@ -424,7 +387,6 @@ bool RemillArgumentRecovery::runOnModule(llvm::Module &module) {
       auto arg_name = TrimPrefix(arg.getName());
       auto var = remill::FindVarInFunction(new_func, arg_name);
       arg.takeName(var);
-      removeAttr(arg, llvm::Attribute::Dereferenceable);
     }
     assert(old_func->use_empty());
     old_func->replaceAllUsesWith(llvm::UndefValue::get(old_func->getType()));

--- a/fcd/passes.h
+++ b/fcd/passes.h
@@ -16,7 +16,11 @@
 
 #include "fcd/ast/pass_backend.h"
 #include "fcd/pass_asaa.h"
+#include "fcd/pass_argrec_remill.h"
+#include "fcd/pass_stackrec_remill.h"
+#include "fcd/pass_intrinsics_remill.h"
 
 llvm::FunctionPass*	createRegisterPointerPromotionPass();
+llvm::FunctionPass* createSignExtPass();
 
 #endif /* defined(fcd__passes_h) */


### PR DESCRIPTION
This MR contains assorted bug fixes, bringing fcd+remill to a point where it is able to successfully decompile a simple function using debug build of [LLVM-7.0](https://github.com/llvm-mirror/llvm/commits/release_70) and [latest version of Remill](https://github.com/trailofbits/remill/commit/2e77dc7273ba0299f93f7aa3004744a009108a9a).

LLVM versions pre 7.0 have a bug where removal of the `dereferencable` attributes triggers an assertion in debug build and reads memory out of bounds in release build, fixed in [9bc0b1080f195636fed019bce979aa72892d6c69](https://github.com/llvm-mirror/llvm/commit/9bc0b1080f195636fed019bce979aa72892d6c69).